### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false


### PR DESCRIPTION
Adds `.clippy.toml` with `avoid-breaking-exported-api = false` for consistent clippy behavior.

Validated with `cargo clippy --workspace --all-targets --all-features`.