### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/benches/transformer.rs
+++ b/benches/transformer.rs
@@ -22,9 +22,7 @@ trait TheBencher {
     ) {
         let cpus = num_cpus::get_physical();
         let id = BenchmarkId::new(Self::ID, "single-thread");
-        g.bench_with_input(id, &source, |b, source| {
-            b.iter(|| Self::run(path, source, options))
-        });
+        g.bench_with_input(id, &source, |b, source| b.iter(|| Self::run(path, source, options)));
 
         let id = BenchmarkId::new(Self::ID, "no-drop");
         g.bench_with_input(id, &source, |b, source| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,7 @@ pub mod oxc {
         let source_type = SourceType::from_path(path).unwrap();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let mut program = ret.program;
-        let scoping = SemanticBuilder::new()
-            .build(&program)
-            .semantic
-            .into_scoping();
+        let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
         let ret =
             Transformer::new(&allocator, path, options).build_with_scoping(scoping, &mut program);
         assert!(ret.diagnostics.is_empty());


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
