### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,9 @@ codegen-units = 1
 strip = "symbols"
 debug = false
 panic = "abort"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.